### PR TITLE
output errors in a tidy machine readable way

### DIFF
--- a/cape-map.js
+++ b/cape-map.js
@@ -6,31 +6,57 @@ It's generally intended to usually be used via a Azure pipeline.
 
 Usage:
 node cape-map.js <config.json> <dataset1> (<dataset2> ...)
- */
+*/
+
 import { readFileSync } from 'fs';
 import { SiteMapper } from "./lib/CapeMapper/SiteMapper.js";
 
-let args = process.argv;
-args.shift(); // node
-args.shift(); // this script
-const json_config_file = args.shift();
-const tabular_files = args;
+var output_data;
+try { 
+    let args = process.argv;
 
-const rawData = readFileSync(json_config_file).toString();
-let config = JSON.parse(rawData);
+    args.shift(); // node
+    args.shift(); // this script
+    if( args.length < 2 ) {
+        throw new Error( "cape-mapper expects at least two arguments" );
+    }
+    const json_config_file = args.shift();
+    const tabular_files = args;
+    
+    const rawData = readFileSync(json_config_file).toString();
+    let config = JSON.parse(rawData);
 
-let tabular_datasets = [];
-tabular_files.forEach((filename) => {
-    let buffer = readFileSync(filename);
-    tabular_datasets.push(buffer);
-})
+    // at this stage we open the files as buffers to pass them to the generate function
+    // which will check they actually contain what we expect. The only errors caught at
+    // this level is failing to open them.
+    let tabular_datasets = [];
+    tabular_files.forEach((filename) => {
+        let buffer = readFileSync(filename);
+        tabular_datasets.push(buffer);
+    })
 
-let mapper = new SiteMapper(config);
-const first_dataset_id = config['datasets'][0]['id'];
-let site_datasets = {};
-site_datasets[first_dataset_id] = tabular_datasets;
 
-const site_data = mapper.generate(site_datasets);
+    // the config allows multiple datasets, but this tool only supports one.
+    if( config['datasets'].length > 1 ) {
+        throw new Error( "cape-mapper only supports exactly one dataset" );
+    }
+    let mapper = new SiteMapper(config);
+    const first_dataset_id = config['datasets'][0]['id'];
+    let site_datasets = {};
+    site_datasets[first_dataset_id] = tabular_datasets;
+
+    // In azure functions, this function is what is called:
+    output_data = mapper.generate(site_datasets);
+}
+catch( error ) {
+    output_data = {
+      "status": "ERROR",
+      "errors": [ error.toString() ]
+    };
+    // Give full details to STDERR
+    console.error( error );
+}
 
 // Pretty print the site JSON file to STDOUT
-console.log(JSON.stringify(site_data, null, 4));
+const output_string = JSON.stringify( output_data, null, 4 );
+console.log(output_string);

--- a/lib/CapeMapper/DatasetMapper.js
+++ b/lib/CapeMapper/DatasetMapper.js
@@ -126,9 +126,9 @@ class DatasetMapper {
             }); // end of foreach incoming_record
 
             // note any headings that were never used once we've done the whole table
-            output.unmapped_headings.push(Object.keys(unmapped_headings_in_table));
+            output.unmapped_headings = output.unmapped_headings.concat(Object.keys(unmapped_headings_in_table));
             // ... and any headings we were missing
-            output.missing_headings.push(Object.keys(missing_headings));
+            output.missing_headings = output.missing_headings.concat(Object.keys(missing_headings));
 
         }); // end of foreach byteStream
 

--- a/lib/CapeMapper/SiteMapper.js
+++ b/lib/CapeMapper/SiteMapper.js
@@ -31,14 +31,48 @@ class SiteMapper {
     /**
      *  load relevant files from filesystem and map them using the config. nb. this will not work with azure
      *  @param {Object.<string,Buffer|Buffer[]>} source_data. An array of byte streams to import for each dataset. The key is the ID of the dataset.
-     *  @return {Object}
+     *  @return {Array}
      */
     generate(source_data) {
-        let output = { status:"OK", datasets: []};
-        this.datasetMappers.forEach( (dataset_mapper) => {
-           output.datasets.push( dataset_mapper.generate( source_data[ dataset_mapper.config.id ] ));
-        });
-        return output;
+        var output_data;
+        try {
+            var issues = [];
+            var datasets = [];
+            this.datasetMappers.forEach( (dataset_mapper) => {
+                const dataset_output = dataset_mapper.generate( source_data[ dataset_mapper.config.id ] );
+                datasets.push( dataset_output );
+
+                // turn any issues into errors
+                if( dataset_output.unmapped_headings.length > 0 ) {
+                    issues.push( "Dataset "+dataset_mapper.config.id+" has the following unexpected headings: " 
+                        + dataset_output.unmapped_headings.join( ", " ) );
+                }
+                if( dataset_output.missing_headings.length  > 0 ) {
+                    issues.push( "Dataset "+dataset_mapper.config.id+" has the following headings expected but missing from all data sources: " 
+                        + dataset_output.missing_headings.join( ", " ) );
+                }
+            });
+            if( issues.length ) {
+                output_data = {
+                    "status": "ERROR",
+                    "errors": issues
+                };
+            } else {
+                output_data = { 
+                    "status":"OK", 
+                    "datasets": datasets 
+                };
+            }
+        }
+        catch( error ) {
+            output_data = {
+                "status": "ERROR",
+                "errors": [ error.toString() ] 
+            };
+            // Give full details to STDERR
+            console.error( error );
+        }
+        return output_data;
     }
 
 }


### PR DESCRIPTION
This alters both the command line script and the main mapper function to return exceptions and other issues in a datastructure rather than just exception.

The site-mapper.js level can catch missing file names, or load errors which are not the problem of the library.

The SiteMapper generate() function now catches exceptions and issues with missing/extra headers and reports them as errors in the response. It still reports exceptions with a stack trace to stderr to help debugging.

Finally, I fixed a bug in the dataset mapper that when it loops over input spreadsheets it appended an array of missing terms to the relevant field in the output rather than concatonated it meaning there was a [ [1,2],[3,4] ] structure which should have been [1,2,3,4] -- fixed by changing from push to concat.